### PR TITLE
Added support for DataFrames

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,0 +1,3 @@
+DataArrays
+NamedArrays
+Requires

--- a/src/Tables.jl
+++ b/src/Tables.jl
@@ -1,6 +1,7 @@
 module Tables
     using DataArrays
     using NamedArrays
+    using Requires
 
     include("freqtable.jl")
 

--- a/src/freqtable.jl
+++ b/src/freqtable.jl
@@ -199,3 +199,16 @@ function freqtable(x::PooledDataVector...; usena::Bool = false)
 	    NamedArray(a, ntuple(n, i -> lev[i]), ntuple(n, i -> "Dim$i"))
 	end
 end
+
+@require DataFrames begin
+
+    using DataFrames
+
+    function Tables.freqtable(x::DataFrame, columns::Symbol...)
+        cols = [x[i] for i in columns]
+        t = freqtable(cols...)
+        setdimnames!(t, columns)
+        t
+    end
+
+end


### PR DESCRIPTION
Hi Milan, 

As always, I am desperately in need of freqtable()...  I just added freqtable(::DataFrame, columns...) as a wrapper.  

``` julia
df = DataFrame(a=[1, 1, 2, 1, 2], b=[1, 3, 2, 2, 1])
freqtable(df, :a, :b)
```

The wrapper loads on loading DataFrames. 
