### PR TITLE
convenience function to handle simple dataframes of uniform type

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,30 +69,46 @@ setosa              28    22
 versicolor          3     8    
 ```
 
-When working with a dataframe where all values are of the same type (e.g. unlabeled data, or a subset of a larger dataframe that also contains strings, Float64s, etc.), you can pass just the dataframe (or subset of the dataframe) of interest
+`rowwisecounts` and `colwisecounts` can be used to tabulate the occurances of each unique variable across rows or columns of a `DataFrame` or `Array`, given that the dataset is of a uniform type
 ```julia
-julia> df = DataFrame(s1 = repeat(collect(1:3), inner=4), s2 = repeat(collect(1:3), outer=4), s3 = fill(1, 12))
-12×3 DataFrames.DataFrame
-│ Row │ s1 │ s2 │ s3 │
-├─────┼────┼────┼────┤
-│ 1   │ 1  │ 1  │ 1  │
-│ 2   │ 1  │ 2  │ 1  │
-│ 3   │ 1  │ 3  │ 1  │
-│ 4   │ 1  │ 1  │ 1  │
-│ 5   │ 2  │ 2  │ 1  │
-│ 6   │ 2  │ 3  │ 1  │
-│ 7   │ 2  │ 1  │ 1  │
-│ 8   │ 2  │ 2  │ 1  │
-│ 9   │ 3  │ 3  │ 1  │
-│ 10  │ 3  │ 1  │ 1  │
-│ 11  │ 3  │ 2  │ 1  │
-│ 12  │ 3  │ 3  │ 1  │
+julia> data
+12×4 Array{Symbol,2}:
+ :a  :a  :a  :d
+ :a  :b  :a  :d
+ :a  :c  :a  :d
+ :a  :a  :a  :d
+ :b  :b  :a  :d
+ :b  :c  :a  :d
+ :b  :a  :a  :d
+ :b  :b  :a  :d
+ :c  :c  :a  :d
+ :c  :a  :a  :d
+ :c  :b  :a  :d
+ :c  :c  :a  :d
 
-julia> freqtable(df)
-3×3 Named Array{Int64,2}
-value ╲ column │ s1  s2  s3
-───────────────┼───────────
-1              │  4   4  12
-2              │  4   4   0
-3              │  4   4   0
+julia> colwisecounts(data)
+4×4 Named Array{Int64,2}
+value ╲ column │  1   2   3   4
+───────────────┼───────────────
+a              │  4   4  12   0
+b              │  4   4   0   0
+c              │  4   4   0   0
+d              │  0   0   0  12
+
+julia> rowwisecounts(data)
+12×4 Named Array{Int64,2}
+row ╲ value │ a  b  c  d
+────────────┼───────────
+1           │ 3  0  0  1
+2           │ 2  1  0  1
+3           │ 2  0  1  1
+4           │ 3  0  0  1
+5           │ 1  2  0  1
+6           │ 1  1  1  1
+7           │ 2  1  0  1
+8           │ 1  2  0  1
+9           │ 1  0  2  1
+10          │ 2  0  1  1
+11          │ 1  1  1  1
+12          │ 1  0  2  1
 ```

--- a/src/FreqTables.jl
+++ b/src/FreqTables.jl
@@ -6,4 +6,6 @@ module FreqTables
     include("freqtable.jl")
 
     export freqtable
+    export colwisecounts
+    export rowwisecounts
 end # module

--- a/src/freqtable.jl
+++ b/src/freqtable.jl
@@ -155,3 +155,8 @@ function freqtable(d::DataFrame, x::Symbol...; args...)
     setdimnames!(a, x)
     a
 end
+
+function freqtable(df::DataFrame)
+	stacked = names!(stack(df, 1:size(df,2)), [:column, :value])
+	return freqtable(stacked, :value, :column)
+end

--- a/src/freqtable.jl
+++ b/src/freqtable.jl
@@ -156,7 +156,29 @@ function freqtable(d::DataFrame, x::Symbol...; args...)
     a
 end
 
-function freqtable(df::DataFrame)
-	stacked = names!(stack(df, 1:size(df,2)), [:column, :value])
-	return freqtable(stacked, :value, :column)
+function colwisecounts(df::DataFrame)
+    stacked = names!(stack(df, 1:size(df,2)), [:column, :value])
+    return freqtable(stacked, :value, :column)
+end
+
+function colwisecounts(a::Array{ANY, 2})
+    uniques = sort!(unique(a))
+    count_matrix = Array{Int}(length(uniques), size(a,2))
+    for col in 1:size(a,2)
+        for (row, u) in enumerate(uniques)
+            count_matrix[row, col] = count(i -> i == u, a[:, col])
+        end
+    end
+    NamedArray(count_matrix, (uniques, collect(1:size(a,2))), ("value", "column"))
+end
+
+function rowwisecounts(a::Array{ANY, 2})
+    uniques = sort!(unique(a))
+    count_matrix = Array{Int}(size(a,1), length(uniques))
+    for row in 1:size(a,1)
+        for (col, u) in enumerate(uniques)
+            count_matrix[row, col] = count(i -> i == u, a[row, :])
+        end
+    end
+    NamedArray(count_matrix, (collect(1:size(a,1)), uniques), ("row", "value"))
 end

--- a/src/freqtable.jl
+++ b/src/freqtable.jl
@@ -156,12 +156,7 @@ function freqtable(d::DataFrame, x::Symbol...; args...)
     a
 end
 
-function colwisecounts(df::DataFrame)
-    stacked = names!(stack(df, 1:size(df,2)), [:column, :value])
-    return freqtable(stacked, :value, :column)
-end
-
-function colwisecounts(a::Array{ANY, 2})
+function colwisecounts(a::Array)
     uniques = sort!(unique(a))
     count_matrix = Array{Int}(length(uniques), size(a,2))
     for col in 1:size(a,2)
@@ -172,7 +167,7 @@ function colwisecounts(a::Array{ANY, 2})
     NamedArray(count_matrix, (uniques, collect(1:size(a,2))), ("value", "column"))
 end
 
-function rowwisecounts(a::Array{ANY, 2})
+function rowwisecounts(a::Array)
     uniques = sort!(unique(a))
     count_matrix = Array{Int}(size(a,1), length(uniques))
     for row in 1:size(a,1)
@@ -181,4 +176,13 @@ function rowwisecounts(a::Array{ANY, 2})
         end
     end
     NamedArray(count_matrix, (collect(1:size(a,1)), uniques), ("row", "value"))
+end
+
+function colwisecounts(df::DataFrame)
+    stacked = names!(stack(df, 1:size(df,2)), [:column, :value])
+    return freqtable(stacked, :value, :column)
+end
+
+function rowwisecounts(df::DataFrame)
+    rowwisecounts(Array(df))
 end

--- a/test/freqtable.jl
+++ b/test/freqtable.jl
@@ -1,6 +1,7 @@
 using FreqTables
 using Base.Test
 using NamedArrays
+using DataFrames
 
 x = repeat(["a", "b", "c", "d"], outer=[100]);
 y = repeat(["A", "B", "C", "D"], inner=[10], outer=[10]);
@@ -65,9 +66,39 @@ iris[:LongSepal] = iris[:SepalLength] .> 5.0
 @test freqtable([Set(1), Set(2)], [Set(1), Set(2)]).array == eye(2)
 
 #
-srand(1);
-s1 = sample(1:3, 30);
-s2 = sample(1:3, 30);
-s3 = sample(1:3, WeightVec([.9, .05, .05]), 30);
-data = DataFrame(s1 = s1, s2 = s2, s3 = s3)
-@test freqtable(data) == NamedArray(reshape([7, 10, 13, 17, 7, 6, 24, 3, 3], (3,3)), ([1, 2, 3], [:s1, :s2, :s3]), ("value", "column"))
+sample1 = repeat([:a, :b, :c], inner=4)
+sample2 = repeat([:a, :b, :c], outer=4)
+sample3 = fill(:a, 12)
+sample4 = fill(:d, 12)
+data = DataFrame(sample1 = sample1,
+                    sample2 = sample2,
+                        sample3 = sample3,
+                            sample4 = sample4)
+
+a = [4 4 12  0;
+     4 4  0  0;
+     4 4  0  0;
+     0 0  0 12]
+rows = [:a, :b, :c, :d]
+columns = [:sample1, :sample2, :sample3, :sample4]
+@test colwisecounts(data) == NamedArray(a, (rows, columns), ("value", "column"))
+
+data = Array(data)
+columns = [1, 2, 3, 4]
+@test colwisecounts(data) == NamedArray(a, (rows, columns), ("value", "column"))
+
+
+a = [3 0 0 1;
+     2 1 0 1;
+     2 0 1 1;
+     3 0 0 1;
+     1 2 0 1;
+     1 1 1 1;
+     2 1 0 1;
+     1 2 0 1;
+     1 0 2 1;
+     2 0 1 1;
+     1 1 1 1;
+     1 0 2 1;]
+columns, rows = rows, collect(1:12)
+@test rowwisecounts(data) == NamedArray(a, (rows, columns), ("row", "value"))

--- a/test/freqtable.jl
+++ b/test/freqtable.jl
@@ -1,5 +1,6 @@
 using FreqTables
 using Base.Test
+using NamedArrays
 
 x = repeat(["a", "b", "c", "d"], outer=[100]);
 y = repeat(["A", "B", "C", "D"], inner=[10], outer=[10]);
@@ -62,3 +63,11 @@ iris[:LongSepal] = iris[:SepalLength] .> 5.0
 # Issue #5
 @test freqtable([Set(1), Set(2)]).array == [1, 1]
 @test freqtable([Set(1), Set(2)], [Set(1), Set(2)]).array == eye(2)
+
+#
+srand(1);
+s1 = sample(1:3, 30);
+s2 = sample(1:3, 30);
+s3 = sample(1:3, WeightVec([.9, .05, .05]), 30);
+data = DataFrame(s1 = s1, s2 = s2, s3 = s3)
+@test freqtable(data) == NamedArray(reshape([7, 10, 13, 17, 7, 6, 24, 3, 3], (3,3)), ([1, 2, 3], [:s1, :s2, :s3]), ("value", "column"))

--- a/test/freqtable.jl
+++ b/test/freqtable.jl
@@ -70,6 +70,31 @@ sample1 = repeat([:a, :b, :c], inner=4)
 sample2 = repeat([:a, :b, :c], outer=4)
 sample3 = fill(:a, 12)
 sample4 = fill(:d, 12)
+data = hcat(sample1, sample2, sample3, sample4)
+
+a = [4 4 12  0;
+     4 4  0  0;
+     4 4  0  0;
+     0 0  0 12]
+rows = [:a, :b, :c, :d]
+columns = [1, 2, 3, 4]
+@test colwisecounts(data) == NamedArray(a, (rows, columns), ("value", "column"))
+
+a = [3 0 0 1;
+     2 1 0 1;
+     2 0 1 1;
+     3 0 0 1;
+     1 2 0 1;
+     1 1 1 1;
+     2 1 0 1;
+     1 2 0 1;
+     1 0 2 1;
+     2 0 1 1;
+     1 1 1 1;
+     1 0 2 1;]
+columns, rows = rows, collect(1:12)
+@test rowwisecounts(data) == NamedArray(a, (rows, columns), ("row", "value"))
+
 data = DataFrame(sample1 = sample1,
                     sample2 = sample2,
                         sample3 = sample3,
@@ -82,11 +107,6 @@ a = [4 4 12  0;
 rows = [:a, :b, :c, :d]
 columns = [:sample1, :sample2, :sample3, :sample4]
 @test colwisecounts(data) == NamedArray(a, (rows, columns), ("value", "column"))
-
-data = Array(data)
-columns = [1, 2, 3, 4]
-@test colwisecounts(data) == NamedArray(a, (rows, columns), ("value", "column"))
-
 
 a = [3 0 0 1;
      2 1 0 1;


### PR DESCRIPTION
Hi Milan,

This pull request would enable FreqTables to work on a DataFrame where multiple columns are of the same type, and the user would like to tabulate the frequency of each unique value among the columns.

**Current behavior**

```
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
   _ _   _| |_  __ _   |  Type "?help" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.5.1-pre+3 (2016-10-27 05:50 UTC)
 _/ |\__'_|_|_|\__'_|  |  Commit 76c93bf (3 days old release-0.5)
|__/                   |  x86_64-apple-darwin16.1.0

julia> using DataFrames

julia> using FreqTables

julia> using StatsBase

julia> srand(1);

julia> s1 = sample(1:3, 30);

julia> s2 = sample(1:3, 30);

julia> s3 = sample(1:3, WeightVec([.9, .05, .05]), 30);

julia> data = DataFrame(s1 = s1, s2 = s2, s3 = s3)
30×3 DataFrames.DataFrame
│ Row │ s1 │ s2 │ s3 │
├─────┼────┼────┼────┤
│ 1   │ 1  │ 1  │ 2  │
│ 2   │ 2  │ 1  │ 1  │
│ 3   │ 3  │ 1  │ 1  │
│ 4   │ 3  │ 2  │ 1  │
│ 5   │ 3  │ 2  │ 1  │
│ 6   │ 3  │ 2  │ 1  │
│ 7   │ 1  │ 1  │ 2  │
│ 8   │ 3  │ 1  │ 1  │
│ 9   │ 3  │ 1  │ 1  │
│ 10  │ 1  │ 1  │ 1  │
│ 11  │ 1  │ 2  │ 3  │
│ 12  │ 1  │ 1  │ 1  │
│ 13  │ 2  │ 3  │ 1  │
│ 14  │ 1  │ 2  │ 1  │
│ 15  │ 3  │ 1  │ 1  │
│ 16  │ 2  │ 3  │ 1  │
│ 17  │ 3  │ 1  │ 1  │
│ 18  │ 2  │ 1  │ 1  │
│ 19  │ 3  │ 1  │ 1  │
│ 20  │ 3  │ 3  │ 1  │
│ 21  │ 2  │ 3  │ 1  │
│ 22  │ 2  │ 3  │ 1  │
│ 23  │ 2  │ 1  │ 3  │
│ 24  │ 3  │ 2  │ 1  │
│ 25  │ 3  │ 1  │ 1  │
│ 26  │ 2  │ 1  │ 1  │
│ 27  │ 2  │ 1  │ 1  │
│ 28  │ 3  │ 3  │ 2  │
│ 29  │ 1  │ 1  │ 1  │
│ 30  │ 2  │ 2  │ 3  │

julia> freqtable(data)
ERROR: MethodError: no method matching colon(::Int64, ::TypeVar)
Closest candidates are:
colon{T<:Real}(::T<:Real, ::Any, ::T<:Real) at range.jl:114
colon{A<:Real,C<:Real}(::A<:Real, ::Any, ::C<:Real) at range.jl:112
colon{T}(::T, ::Any, ::T) at range.jl:118
...
in _freqtable(::Tuple{}, ::Bool) at /Users/Cameron/.julia/v0.5/FreqTables/src/freqtable.jl:90
in freqtable() at /Users/Cameron/.julia/v0.5/FreqTables/src/freqtable.jl:151
in #freqtable#15(::Array{Any,1}, ::Function, ::DataFrames.DataFrame) at /Users/Cameron/.julia/v0.5/FreqTables/src/freqtable.jl:154
in freqtable(::DataFrames.DataFrame) at /Users/Cameron/.julia/v0.5/FreqTables/src/freqtable.jl:154
```

**Proposed behavior**

```
julia> data = DataFrame(s1 = s1, s2 = s2, s3 = s3)
30×3 DataFrames.DataFrame
│ Row │ s1 │ s2 │ s3 │
├─────┼────┼────┼────┤
│ 1   │ 1  │ 1  │ 2  │
│ 2   │ 2  │ 1  │ 1  │
│ 3   │ 3  │ 1  │ 1  │
│ 4   │ 3  │ 2  │ 1  │
│ 5   │ 3  │ 2  │ 1  │
│ 6   │ 3  │ 2  │ 1  │
│ 7   │ 1  │ 1  │ 2  │
│ 8   │ 3  │ 1  │ 1  │
│ 9   │ 3  │ 1  │ 1  │
│ 10  │ 1  │ 1  │ 1  │
│ 11  │ 1  │ 2  │ 3  │
│ 12  │ 1  │ 1  │ 1  │
│ 13  │ 2  │ 3  │ 1  │
│ 14  │ 1  │ 2  │ 1  │
│ 15  │ 3  │ 1  │ 1  │
│ 16  │ 2  │ 3  │ 1  │
│ 17  │ 3  │ 1  │ 1  │
│ 18  │ 2  │ 1  │ 1  │
│ 19  │ 3  │ 1  │ 1  │
│ 20  │ 3  │ 3  │ 1  │
│ 21  │ 2  │ 3  │ 1  │
│ 22  │ 2  │ 3  │ 1  │
│ 23  │ 2  │ 1  │ 3  │
│ 24  │ 3  │ 2  │ 1  │
│ 25  │ 3  │ 1  │ 1  │
│ 26  │ 2  │ 1  │ 1  │
│ 27  │ 2  │ 1  │ 1  │
│ 28  │ 3  │ 3  │ 2  │
│ 29  │ 1  │ 1  │ 1  │
│ 30  │ 2  │ 2  │ 3  │

julia> freqtable(data)
3×3 Named Array{Int64,2}
value ╲ column │ s1  s2  s3
───────────────┼───────────
1              │  7  17  24
2              │ 10   7   3
3              │ 13   6   3
```

I'm not sure how common this use case would come up for others, but it came up for me, so I thought I'd see if you were interested in it. I've written a test for this and added an example to the readme.

Worth mentioning, this fails when using a DataFrame of mixed types. In this example, mixed strings and Floats. If you have any suggestions on how to handle this case, I would be interested to hear them!

```
julia> using RDatasets

julia> iris = dataset("datasets", "iris");

julia> data = iris[[:Species, :PetalWidth]];

julia> head(data)
6×2 DataFrames.DataFrame
│ Row │ Species  │ PetalWidth │
├─────┼──────────┼────────────┤
│ 1   │ "setosa" │ 0.2        │
│ 2   │ "setosa" │ 0.2        │
│ 3   │ "setosa" │ 0.2        │
│ 4   │ "setosa" │ 0.2        │
│ 5   │ "setosa" │ 0.2        │
│ 6   │ "setosa" │ 0.4        │

julia> tail(data)
6×2 DataFrames.DataFrame
│ Row │ Species     │ PetalWidth │
├─────┼─────────────┼────────────┤
│ 1   │ "virginica" │ 2.5        │
│ 2   │ "virginica" │ 2.3        │
│ 3   │ "virginica" │ 1.9        │
│ 4   │ "virginica" │ 2.0        │
│ 5   │ "virginica" │ 2.3        │
│ 6   │ "virginica" │ 1.8        │

julia> freqtable(data)
ERROR: ArgumentError: invalid index: 0.1
 in setindex!(::NamedArrays.NamedArray{Int64,2,Array{Int64,2},Tuple{DataStructures.OrderedDict{Any,Int64},DataStructures.OrderedDict{Symbol,Int64}}}, ::Int64, ::Float64, ::Symbol) at /Users/Cameron/.julia/v0.5/NamedArrays/src/index.jl:196
 in _freqtable(::Tuple{DataArrays.PooledDataArray{Any,UInt8,1},Array{Symbol,1}}, ::FreqTables.UnitWeights, ::Void) at /Users/Cameron/.julia/v0.5/FreqTables/src/freqtable.jl:74
 in #freqtable#5(::FreqTables.UnitWeights, ::Void, ::Function, ::DataArrays.PooledDataArray{Any,UInt8,1}, ::Vararg{AbstractArray{T,1},N}) at /Users/Cameron/.julia/v0.5/FreqTables/src/freqtable.jl:80
 in freqtable(::DataArrays.PooledDataArray{Any,UInt8,1}, ::Array{Symbol,1}, ::Vararg{Array{Symbol,1},N}) at /Users/Cameron/.julia/v0.5/FreqTables/src/freqtable.jl:80
 in #freqtable#15(::Array{Any,1}, ::Function, ::DataFrames.DataFrame, ::Symbol, ::Vararg{Symbol,N}) at /Users/Cameron/.julia/v0.5/FreqTables/src/freqtable.jl:154
 in freqtable(::DataFrames.DataFrame) at /Users/Cameron/.julia/v0.5/FreqTables/src/freqtable.jl:161
```
