### PR TITLE
use abstract data frame

### DIFF
--- a/src/freqtable.jl
+++ b/src/freqtable.jl
@@ -151,7 +151,7 @@ end
 
 freqtable(x::PooledDataVector...; usena::Bool = false) = _freqtable(x, usena)
 
-function freqtable(d::DataFrame, x::Symbol...; args...)
+function freqtable(d::AbstractDataFrame, x::Symbol...; args...)
     a = freqtable([d[y] for y in x]...; args...)
     setdimnames!(a, x)
     a


### PR DESCRIPTION
The method signature of `freqtable(d::DataFrame, ::Symbol...; args...)` is unnecessarily restrictive.  Broadening it to `::AbstractDataFrame` allows freq tables to be constructed from `SubDataFrame`s etc.