### PR TITLE
Port to CategoricalArrays and Missings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - osx
   - linux
 julia:
-  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 
 [![Build Status](https://travis-ci.org/nalimilan/FreqTables.jl.svg?branch=master)](https://travis-ci.org/nalimilan/FreqTables.jl)
 [![Coverage Status](https://coveralls.io/repos/nalimilan/FreqTables.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/nalimilan/FreqTables.jl?branch=master)
-[![FreqTables](http://pkg.julialang.org/badges/FreqTables_0.5.svg)](http://pkg.julialang.org/?pkg=FreqTables&ver=0.5)
 [![FreqTables](http://pkg.julialang.org/badges/FreqTables_0.6.svg)](http://pkg.julialang.org/?pkg=FreqTables&ver=0.6)
 
 This package allows computing one- or multi-way frequency tables (a.k.a. contingency or pivot tables) from
-any type of vector or array. It includes support for [`PooledDataArray`s](https://github.com/JuliaStats/DataArrays.jl)
-and [`DataFrame`s](https://github.com/JuliaStats/DataFrames.jl/), as well as for weighted counts.
+any type of vector or array. It includes support for [`CategoricalArray`](https://github.com/JuliaData/CategoricalArrays.jl)
+and [`DataFrame`s](https://github.com/JuliaData/DataFrames.jl), as well as for weighted counts.
 
 Tables are represented as [`NamedArray`](https://github.com/davidavdav/NamedArrays.jl/) objects.
 
@@ -16,55 +15,64 @@ julia> using FreqTables
 julia> x = repeat(["a", "b", "c", "d"], outer=[100]);
 julia> y = repeat(["A", "B", "C", "D"], inner=[10], outer=[10]);
 julia> freqtable(x)
-4-element NamedArrays.NamedArray{Int64,1,Array{Int64,1},Tuple{Dict{ASCIIString,Int64}}}
-a 100
-b 100
-c 100
-d 100
+julia>  freqtable(x)
+4-element Named Array{Int64,1}
+Dim1  │
+──────┼────
+a     │ 100
+b     │ 100
+c     │ 100
+d     │ 100
 
 julia> freqtable(x, y)
-4x4 NamedArrays.NamedArray{Int64,2,Array{Int64,2},Tuple{Dict{ASCIIString,Int64},Dict{ASCIIString,Int64}}}
-Dim1 \ Dim2 A  B  C  D 
-a           30 20 30 20
-b           30 20 30 20
-c           20 30 20 30
-d           20 30 20 30
+4×4 Named Array{Int64,2}
+Dim1 ╲ Dim2 │  A   B   C   D
+────────────┼───────────────
+a           │ 30  20  30  20
+b           │ 30  20  30  20
+c           │ 20  30  20  30
+d           │ 20  30  20  30
 
 julia> freqtable(x, y, subset=1:20)
-4x2 NamedArrays.NamedArray{Int64,2,Array{Int64,2},Tuple{Dict{ASCIIString,Int64},Dict{ASCIIString,Int64}}}
-Dim1 \ Dim2 A B
-a           3 2
-b           3 2
-c           2 3
-d           2 3
+4×2 Named Array{Int64,2}
+Dim1 ╲ Dim2 │ A  B
+────────────┼─────
+a           │ 3  2
+b           │ 3  2
+c           │ 2  3
+d           │ 2  3
 
 julia> freqtable(x, y, subset=1:20, weights=repeat([1, .5], outer=[10]))
-4x2 NamedArrays.NamedArray{Float64,2,Array{Float64,2},Tuple{Dict{ASCIIString,Int64},Dict{ASCIIString,Int64}}}
-Dim1 \ Dim2 A   B  
-a           3.0 2.0
-b           1.5 1.0
-c           2.0 3.0
-d           1.0 1.5
+4×2 Named Array{Float64,2}
+Dim1 ╲ Dim2 │   A    B
+────────────┼─────────
+a           │ 3.0  2.0
+b           │ 1.5  1.0
+c           │ 2.0  3.0
+d           │ 1.0  1.5
 ```
 
 For convenience, when working with a data frame, one can also pass the `DataFrame` object and columns as symbols:
 ```julia
-julia> using RDatasets
+julia> using DataFrames, CSV
 
-julia> iris = dataset("datasets", "iris");
+julia> iris = CSV.read(joinpath(Pkg.dir("DataFrames"), "test/data/iris.csv"));
 
 julia> iris[:LongSepal] = iris[:SepalLength] .> 5.0;
 
 julia> freqtable(iris, :Species, :LongSepal)
-3x2 NamedArrays.NamedArray{Int64,2,Array{Int64,2},Tuple{Dict{ASCIIString,Int64},Dict{Bool,Int64}}}
-Species \ LongSepal false true 
-setosa              28    22   
-versicolor          3     47   
-virginica           1     49   
+3×2 Named Array{Int64,2}
+Species ╲ LongSepal │ false   true
+────────────────────┼─────────────
+setosa              │    28     22
+versicolor          │     3     47
+virginica           │     1     49
 
 julia> freqtable(iris, :Species, :LongSepal, subset=iris[:PetalLength] .< 4.0)
-2x2 NamedArrays.NamedArray{Int64,2,Array{Int64,2},Tuple{Dict{ASCIIString,Int64},Dict{Bool,Int64}}}
-Species \ LongSepal false true 
-setosa              28    22   
-versicolor          3     8    
+julia> freqtable(iris, :Species, :LongSepal, subset=iris[:PetalLength] .< 4.0)
+2×2 Named Array{Int64,2}
+Species ╲ LongSepal │ false   true
+────────────────────┼─────────────
+setosa              │    28     22
+versicolor          │     3      8
 ```

--- a/README.md
+++ b/README.md
@@ -6,16 +6,18 @@
 
 This package allows computing one- or multi-way frequency tables (a.k.a. contingency or pivot tables) from
 any type of vector or array. It includes support for [`CategoricalArray`](https://github.com/JuliaData/CategoricalArrays.jl)
-and [`DataFrame`s](https://github.com/JuliaData/DataFrames.jl), as well as for weighted counts.
+and [`DataFrame`](https://github.com/JuliaData/DataFrames.jl), as well as for weighted counts.
 
 Tables are represented as [`NamedArray`](https://github.com/davidavdav/NamedArrays.jl/) objects.
 
 ```julia
 julia> using FreqTables
+
 julia> x = repeat(["a", "b", "c", "d"], outer=[100]);
+
 julia> y = repeat(["A", "B", "C", "D"], inner=[10], outer=[10]);
+
 julia> freqtable(x)
-julia>  freqtable(x)
 4-element Named Array{Int64,1}
 Dim1  │
 ──────┼────
@@ -52,7 +54,7 @@ c           │ 2.0  3.0
 d           │ 1.0  1.5
 ```
 
-For convenience, when working with a data frame, one can also pass the `DataFrame` object and columns as symbols:
+For convenience, when working with a data frame, one can also pass a `DataFrame` object and columns as symbols:
 ```julia
 julia> using DataFrames, CSV
 
@@ -68,7 +70,6 @@ setosa              │    28     22
 versicolor          │     3     47
 virginica           │     1     49
 
-julia> freqtable(iris, :Species, :LongSepal, subset=iris[:PetalLength] .< 4.0)
 julia> freqtable(iris, :Species, :LongSepal, subset=iris[:PetalLength] .< 4.0)
 2×2 Named Array{Int64,2}
 Species ╲ LongSepal │ false   true

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.6
 NamedArrays
-DataArrays
-DataFrames
+CategoricalArrays 0.7.0
+DataFrames 0.11.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
 NamedArrays
-CategoricalArrays 0.7.0
+CategoricalArrays 0.3.0
 DataFrames 0.11.0

--- a/src/FreqTables.jl
+++ b/src/FreqTables.jl
@@ -1,5 +1,5 @@
 module FreqTables
-    using DataArrays
+    using CategoricalArrays
     using DataFrames
     using NamedArrays
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,1 @@
-RDatasets
+CSV 0.2.0

--- a/test/freqtable.jl
+++ b/test/freqtable.jl
@@ -2,63 +2,108 @@ using FreqTables
 using Base.Test
 
 x = repeat(["a", "b", "c", "d"], outer=[100]);
-y = repeat(["A", "B", "C", "D"], inner=[10], outer=[10]);
+# Values not in order to test discrepancy between index and levels with CategoricalArray
+y = repeat(["D", "C", "A", "B"], inner=[10], outer=[10]);
 
-@test freqtable(x).array == [100, 100, 100, 100]
-@test freqtable(y).array == [100, 100, 100, 100]
-@test freqtable(x, y).array == [30 20 30 20;
-                                30 20 30 20;
-                                20 30 20 30;
-                                20 30 20 30]
+tab = @inferred freqtable(x)
+@test tab == [100, 100, 100, 100]
+@test names(tab) == [["a", "b", "c", "d"]]
+tab = @inferred freqtable(y)
+@test tab == [100, 100, 100, 100]
+@test names(tab) == [["A", "B", "C", "D"]]
+tab = @inferred freqtable(x, y)
+@test tab == [30 20 20 30;
+              30 20 20 30;
+              20 30 30 20;
+              20 30 30 20]
+@test names(tab) == [["a", "b", "c", "d"], ["A", "B", "C", "D"]]
 
-@test freqtable(x, y,
-                subset=1:20,
-                weights=repeat([1, .5], outer=[10])).array == [3.0 2.0
-                                                               1.5 1.0
-                                                               2.0 3.0
-                                                               1.0 1.5]
-
-
-using DataArrays
-xpda = PooledDataArray(x)
-ypda = PooledDataArray(y)
-
-@test freqtable(xpda).array == [100, 100, 100, 100]
-@test freqtable(ypda).array == [100, 100, 100, 100]
-@test freqtable(xpda, ypda).array == [30 20 30 20;
-                                      30 20 30 20;
-                                      20 30 20 30;
-                                      20 30 20 30]
-
-xpda[1] = NA
-ypda[[1, 10, 20, 400]] = NA
-
-@test freqtable(xpda).array == [99, 100, 100, 100]
-@test freqtable(ypda).array == [98, 99, 100, 99]
-@test freqtable(xpda, ypda).array == [29 20 30 20;
-                                      29 20 30 20;
-                                      20 30 20 30;
-                                      20 29 20 29]
-
-@test freqtable(xpda, usena=true).array == [99, 100, 100, 100, 1]
-@test freqtable(ypda, usena=true).array == [98, 99, 100, 99, 4]
-@test freqtable(xpda, ypda, usena=true).array == [29 20 30 20 0;
-                                                  29 20 30 20 1;
-                                                  20 30 20 30 0;
-                                                  20 29 20 29 2;
-                                                  0 0 0 0 1]
+tab =freqtable(x, y,
+               subset=1:20,
+               weights=repeat([1, .5], outer=[10]))
+@test tab == [2.0 3.0
+              1.0 1.5
+              3.0 2.0
+              1.5 1.0]
+@test names(tab) == [["a", "b", "c", "d"], ["C", "D"]]
 
 
-using RDatasets
-iris = dataset("datasets", "iris")
+using CategoricalArrays
+cx = CategoricalArray(x)
+cy = CategoricalArray(y)
+
+tab = @inferred freqtable(cx)
+@test tab == [100, 100, 100, 100]
+@test names(tab) == [["a", "b", "c", "d"]]
+tab = @inferred freqtable(cy)
+@test tab == [100, 100, 100, 100]
+@test names(tab) == [["A", "B", "C", "D"]]
+tab = @inferred freqtable(cx, cy)
+@test tab == [30 20 20 30;
+              30 20 20 30;
+              20 30 30 20;
+              20 30 30 20]
+@test names(tab) == [["a", "b", "c", "d"], ["A", "B", "C", "D"]]
+
+
+using Missings
+const ≅ = isequal
+mx = Array{Union{String, Missing}}(x)
+my = Array{Union{String, Missing}}(y)
+mx[1] = missing
+my[[1, 10, 20, 400]] = missing
+
+mcx = categorical(mx)
+mcy = categorical(my)
+
+tab = freqtable(mx)
+tabc = freqtable(mcx)
+@test tab == tabc == [99, 100, 100, 100, 1]
+@test names(tab) ≅ names(tabc) ≅ [["a", "b", "c", "d", missing]]
+tab = freqtable(my)
+tabc = freqtable(mcy)
+@test tab == tabc == [100, 99, 99, 98, 4]
+@test names(tab) ≅ names(tabc) ≅ [["A", "B", "C", "D", missing]]
+tab = freqtable(mx, my)
+tabc = freqtable(mcx, mcy)
+@test tab == tabc == [30 20 20 29 0;
+                      30 20 20 29 1;
+                      20 30 30 20 0;
+                      20 29 29 20 2;
+                      0   0  0  0 1]
+@test names(tab) ≅ names(tabc) ≅ [["a", "b", "c", "d", missing],
+                                  ["A", "B", "C", "D", missing]]
+
+
+tab = freqtable(mx, skipmissing=true)
+tabc = freqtable(mcx, skipmissing=true)
+@test tab == tabc == [99, 100, 100, 100]
+@test names(tab) ≅ names(tabc) ≅ [["a", "b", "c", "d"]]
+tab = freqtable(my, skipmissing=true)
+tabc = freqtable(mcy, skipmissing=true)
+@test names(tab) ≅ names(tabc) ≅ [["A", "B", "C", "D"]]
+@test tab == tabc == [100, 99, 99, 98]
+tab = freqtable(mx, my, skipmissing=true)
+tabc = freqtable(mcx, mcy, skipmissing=true)
+@test tab == tabc == [30 20 20 29;
+                      30 20 20 29;
+                      20 30 30 20;
+                      20 29 29 20]
+
+
+using DataFrames, CSV
+iris = CSV.read(joinpath(Pkg.dir("DataFrames"), "test/data/iris.csv"), categorical=false);
 iris[:LongSepal] = iris[:SepalLength] .> 5.0
-@test freqtable(iris, :Species, :LongSepal).array == [28 22
-                                                       3 47
-                                                       1 49]
-@test freqtable(iris, :Species, :LongSepal,
-                subset=iris[:PetalLength] .< 4.0).array ==[28 22
-                                                            3  8]
+tab = freqtable(iris, :Species, :LongSepal)
+@test tab == [28 22
+               3 47
+               1 49]
+@test names(tab) == [["setosa", "versicolor", "virginica"], [false, true]]
+tab = freqtable(iris, :Species, :LongSepal, subset=iris[:PetalLength] .< 4.0)
+@test tab == [28 22
+               3  8]
+@test names(tab) == [["setosa", "versicolor"], [false, true]]
 
 # Issue #5
-@test freqtable([Set(1), Set(2)]).array == [1, 1]
-@test freqtable([Set(1), Set(2)], [Set(1), Set(2)]).array == eye(2)
+@test freqtable([Set(1), Set(2)]) == [1, 1]
+@test freqtable([Set(1), Set(2)], [Set(1), Set(2)]) == eye(2)


### PR DESCRIPTION
Breaking change: rename usena to skipmissing, and change default
to keep missing values. Also rework `CategoricalArray` method to make
it simpler. Ensure that type inference works when input arrays do not
support missing values. Improve tests.

@quinnj Working with a `DataFrame` importing using CSV.jl gives corrupted `WeakRefString` objects in the following example:
```julia
using DataFrames, CSV
iris = CSV.read(joinpath(Pkg.dir("DataFrames"), "test/data/iris.csv"), categorical=false);
iris[:LongSepal] = iris[:SepalLength] .> 5.0
tab = freqtable(iris, :Species, :LongSepal)
```
Sometimes, printing `tab` fails since the dimension names appear to have been freed. That's really problematic. Any plans to prevent this?