### PR TITLE
Remove use of Tables.istable

### DIFF
--- a/src/freqtable.jl
+++ b/src/freqtable.jl
@@ -191,7 +191,6 @@ freqtable(x::AbstractCategoricalVector...; skipmissing::Bool = false,
     _freqtable(x, skipmissing, weights, subset)
 
 function freqtable(t, cols::Symbol...; args...)
-    Tables.istable(t) || throw(ArgumentError("data must be a table"))
     all_cols = Tables.columns(t)
     a = freqtable((getproperty(all_cols, y) for y in cols)...; args...)
     setdimnames!(a, cols)


### PR DESCRIPTION
@nalimilan, this would allow additional types where we don't know even at runtime if they're a valid "table" or not. `Tables.columns` itself will throw an error if the input is indeed not a table. 