### PR TITLE
Allow strings for column names

### DIFF
--- a/src/freqtable.jl
+++ b/src/freqtable.jl
@@ -194,7 +194,8 @@ freqtable(x::AbstractCategoricalVector...; skipmissing::Bool = false,
 function freqtable(t, cols::Union{Symbol, AbstractString}...; args...)
     all_cols = Tables.columns(t)
     a = freqtable((Tables.getcolumn(all_cols, Symbol(y)) for y in cols)...; args...)
-    setdimnames!(a, cols)
+    cols′ = all(x -> x isa AbstractString, cols) ? cols : Symbol.(cols)
+    setdimnames!(a, cols′)
     a
 end
 

--- a/src/freqtable.jl
+++ b/src/freqtable.jl
@@ -87,7 +87,7 @@ end
               weights::AbstractVector{<:Real} = UnitWeights(),
               subset::Union{Nothing, AbstractVector{Int}, AbstractVector{Bool}} = nothing])
 
-    freqtable(t, cols::Symbol...;
+    freqtable(t, cols::Union{Symbol, AbstractString}...;
               skipmissing::Bool = false,
               weights::AbstractVector{<:Real} = UnitWeights(),
               subset::Union{Nothing, AbstractVector{Int}, AbstractVector{Bool}} = nothing])
@@ -191,9 +191,9 @@ freqtable(x::AbstractCategoricalVector...; skipmissing::Bool = false,
           subset::Union{Nothing, AbstractVector{Int}, AbstractVector{Bool}} = nothing) =
     _freqtable(x, skipmissing, weights, subset)
 
-function freqtable(t, cols::Symbol...; args...)
+function freqtable(t, cols::Union{Symbol, AbstractString}...; args...)
     all_cols = Tables.columns(t)
-    a = freqtable((Tables.getcolumn(all_cols, y) for y in cols)...; args...)
+    a = freqtable((Tables.getcolumn(all_cols, Symbol(y)) for y in cols)...; args...)
     setdimnames!(a, cols)
     a
 end
@@ -286,7 +286,7 @@ prop(tbl::NamedArray{<:Number}; margins=nothing) =
               weights::AbstractVector{<:Real} = UnitWeights(),
               subset::Union{Nothing, AbstractVector{Int}, AbstractVector{Bool}} = nothing])
 
-    proptable(t, cols::Symbol...;
+    proptable(t, cols::Union{Symbol, AbstractString}...;
               margins = nothing,
               skipmissing::Bool = false,
               weights::AbstractVector{<:Real} = UnitWeights(),
@@ -404,5 +404,5 @@ proptable(x::AbstractVector...;
     prop(freqtable(x...,
                    skipmissing=skipmissing, weights=weights, subset=subset), margins=margins)
 
-proptable(t, cols::Symbol...; margins=nothing, kwargs...) =
+proptable(t, cols::Union{Symbol, AbstractString}...; margins=nothing, kwargs...) =
     prop(freqtable(t, cols...; kwargs...), margins=margins)

--- a/test/freqtable.jl
+++ b/test/freqtable.jl
@@ -1,5 +1,6 @@
 using FreqTables
 using Test
+using NamedArrays
 
 x = repeat(["a", "b", "c", "d"], outer=[100]);
 # Values not in order to test discrepancy between index and levels with CategoricalArray
@@ -165,8 +166,11 @@ for docat in [false, true]
         @test tab == [2 3
                     0 5
                     1 6]
-        @test dimnames(tab) == all(x -> x isa AbstractString, cols) ?
-            ["Species", "LongSepal"] : [:Species, :LongSepal]
+        if all(x -> x isa AbstractString, cols)
+            @test dimnames(tab) == ["Species", "LongSepal"]
+        else
+            @test dimnames(tab) == [:Species, :LongSepal]
+        end
         @test names(tab) == [["Iris-setosa", "Iris-versicolor", "Iris-virginica"], [false, true]]
         @test (names(tab, 2) isa CategoricalArray) == docat
     end
@@ -209,7 +213,11 @@ df = DataFrame(x = [1, 2, 1, 2], y = [1, 1, 2, 2], z = ["a", "a", "c", "d"])
 
 for cols in ((:x, :z), ("x", "z"), ("x", :z), (:x, "z"))
     tab = proptable(df, cols...)
-    @test dimnames(tab) == all(x -> x isa AbstractString, cols) ? ["x", "z"] : [:x, :z]
+    if all(x -> x isa AbstractString, cols)
+        @test dimnames(tab) == ["x", "z"]
+    else
+        @test dimnames(tab) == [:x, :z]
+    end
     @test tab == [0.25 0.25 0.0
                   0.25 0.0  0.25]
     @test names(tab) == [[1, 2], ["a", "c", "d"]]

--- a/test/freqtable.jl
+++ b/test/freqtable.jl
@@ -159,15 +159,17 @@ for docat in [false, true]
     else
         iris.LongSepal = iris.SepalLength .> 5.0
     end
-    tab = freqtable(iris, :Species, :LongSepal)
-    @test tab == freqtable(iris, "Species", "LongSepal") ==
-        freqtable(iris, "Species", :LongSepal) ==
-        freqtable(iris, :Species, "LongSepal")
-    @test tab == [2 3
-                  0 5
-                  1 6]
-    @test names(tab) == [["Iris-setosa", "Iris-versicolor", "Iris-virginica"], [false, true]]
-    @test (names(tab, 2) isa CategoricalArray) == docat
+    for cols in ((:Species, :LongSepal), ("Species", "LongSepal"),
+                 ("Species", :LongSepal), (:Species, "LongSepal"))
+        tab = freqtable(iris, cols...)
+        @test tab == [2 3
+                    0 5
+                    1 6]
+        @test dimnames(tab) == all(x -> x isa AbstractString, cols) ?
+            ["Species", "LongSepal"] : [:Species, :LongSepal]
+        @test names(tab) == [["Iris-setosa", "Iris-versicolor", "Iris-virginica"], [false, true]]
+        @test (names(tab, 2) isa CategoricalArray) == docat
+    end
 
     tab = freqtable(iris, :Species, :LongSepal, subset=iris.SepalWidth .< 3.8)
     @test tab == [2 0
@@ -205,13 +207,13 @@ intft = freqtable(df, :A, :B)
 # proptable
 df = DataFrame(x = [1, 2, 1, 2], y = [1, 1, 2, 2], z = ["a", "a", "c", "d"])
 
-tab = proptable(df, :x, :z)
-@test tab == proptable(df, "x", "z") ==
-    proptable(df, "x", :z)
-    proptable(df, :x, "z")
-@test tab == [0.25 0.25 0.0
-              0.25 0.0  0.25]
-@test names(tab) == [[1, 2], ["a", "c", "d"]]
+for cols in ((:x, :z), ("x", "z"), ("x", :z), (:x, "z"))
+    tab = proptable(df, cols...)
+    @test dimnames(tab) == all(x -> x isa AbstractString, cols) ? ["x", "z"] : [:x, :z]
+    @test tab == [0.25 0.25 0.0
+                  0.25 0.0  0.25]
+    @test names(tab) == [[1, 2], ["a", "c", "d"]]
+end
 
 tab = proptable(df, :x, :z, margins=1)
 @test tab == [0.5 0.5 0.0

--- a/test/freqtable.jl
+++ b/test/freqtable.jl
@@ -160,6 +160,9 @@ for docat in [false, true]
         iris.LongSepal = iris.SepalLength .> 5.0
     end
     tab = freqtable(iris, :Species, :LongSepal)
+    @test tab == freqtable(iris, "Species", "LongSepal") ==
+        freqtable(iris, "Species", :LongSepal) ==
+        freqtable(iris, :Species, "LongSepal")
     @test tab == [2 3
                   0 5
                   1 6]
@@ -203,6 +206,9 @@ intft = freqtable(df, :A, :B)
 df = DataFrame(x = [1, 2, 1, 2], y = [1, 1, 2, 2], z = ["a", "a", "c", "d"])
 
 tab = proptable(df, :x, :z)
+@test tab == proptable(df, "x", "z") ==
+    proptable(df, "x", :z)
+    proptable(df, :x, "z")
 @test tab == [0.25 0.25 0.0
               0.25 0.0  0.25]
 @test names(tab) == [[1, 2], ["a", "c", "d"]]


### PR DESCRIPTION
Since these are allowed by DataFrames.

Fixes #51.