### PR TITLE
Remove unnecessary prop(::NamedArray, ...) method

### DIFF
--- a/src/freqtable.jl
+++ b/src/freqtable.jl
@@ -277,9 +277,6 @@ function prop(tbl::AbstractArray{<:Number,N}; margins=nothing) where N
     end
 end
 
-prop(tbl::NamedArray{<:Number}; margins=nothing) =
-    NamedArray(prop(convert(Array, tbl); margins=margins), tbl.dicts, tbl.dimnames)
-
 """
     proptable(x::AbstractVector...;
               margins = nothing,


### PR DESCRIPTION
@bkamins I guess it used to be needed but that doesn't seem to be the case anymore.